### PR TITLE
fix async-echo-server compile error and improve Ipv4Addr::new()

### DIFF
--- a/async-echo-server/src/reactor.rs
+++ b/async-echo-server/src/reactor.rs
@@ -1,8 +1,8 @@
 use super::*;
 
 pub struct Reactor {
-    epoll: Epoll,
-    wakers: Mutex<HashMap<RawFd, Waker>>,
+    pub epoll: Epoll,
+    pub wakers: Mutex<HashMap<RawFd, Waker>>,
 }
 
 

--- a/async-echo-server/src/util.rs
+++ b/async-echo-server/src/util.rs
@@ -10,3 +10,10 @@ macro_rules! syscall {
         }
     }};
 }
+
+#[link(name = "c")]
+extern "C" {
+    /// htons: H(host byte order) TO N(network byte order) L(Long)
+    /// 为了考虑不同操作系统和处理器的大端序小端序可能不同，所以都转成统一的默认的 network byte order
+    pub fn htonl(hostlong: u32) -> u32;
+}


### PR DESCRIPTION
1. 修复几个没加 pub 的编译错误
2. 引入 htonl 系统调用，兼容不同处理器和操作系统的 IP 地址和 端口号的 byteorder 转换
3. fcntl 一般是在 server_socket_fd 创建之后立即修改 fd 变成 non-block 的属性
示例代码中 listen 之后再改 fd 属性有点不符合 C 语言编程习惯，在 C 语言那些经典的编程书籍中，如果想 fd 设置非阻塞 IO，一般都在 fd 创建后立即修改，这样代码更紧凑，fd 的创建和修改的代码都在一起方便管理